### PR TITLE
feat: Add optional --trust parameter to dingen.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ By letting you define your own system prompts like the [demo home-assistant prom
 ```
 
 Wayyy to long - let's create or own _"dingens"_ by adding an alias in our `.bashrc` or `.zshrc`:
+
 ```bash
 alias werner='dingen.sh ./prompts/home-assistant'
 ``` 
@@ -51,19 +52,23 @@ alias werner='dingen.sh ./prompts/home-assistant'
 To use the script, run the following command in your terminal:
 
 ```
-./dingens.sh <system_prompt_file> [--max-tokens <number>] <user_prompt>
+./dingens.sh <system_prompt_file> [--max-tokens <number>] [--trust] <user_prompt>
 ```
 
 ### Arguments
 
 - `<system_prompt_file>`: Path to the file containing the system prompt.
 - `--max-tokens <number>`: (Optional) Maximum number of tokens for the AI response. Default is 100.
+- `--trust`: (Optional) Runs the generated command directly without user feedback.
 - `<user_prompt>`: The prompt you want to send to the AI.
+
+> **⚠️ Caution:** The `--trust` parameter should be used with care and only after you have validated that your system-prompt returns good results.
 
 ### Example
 
 ```
-./dingens.sh ./prompts/home-assistant "turn off lights in the living room"
+./dingen.sh ./prompts/home-assistant "turn off lights in the living room"
+./dingen.sh ./prompts/home-assistant --trust "turn off lights in the living room"
 ```
 
 ## Dependencies
@@ -82,7 +87,7 @@ To use the script, run the following command in your terminal:
 Given you have the required dependencies installed, you can "install" it on the fly by adding the following alias to your `.bashrc` or `.zshrc`:
 
 ```bash
-alias dingen.sh='function _dingens() { bash -c "$(curl -fsSL https://dingen.sh/script)" -- "$@"; }; _dingens'
+alias dingen.sh='function _dingen() { bash -c "$(curl -fsSL https://dingen.sh/script)" -- "$@"; }; _dingen'
 ```
 
 > **⚠️ Caution:** I would not recommend this for production use for performance and security reasons.
@@ -129,9 +134,9 @@ If you have a useful prompt that you'd like to share, feel free to submit it, an
 
 - [ ] Add tips and tricks for creating own dingens
 - [ ] Add more demo prompts like `docker`, `aws`, `ffmeg`
-- [ ] Add `dingens.sh for <name>` command to use existing prompts hosted on `https://dingen.sh/prompts`
-- [ ] Add `dingens.sh create "a thing to manage <tool>"` command to create new prompts with the help of LLMs (#inception)
-- [ ] Add `dingens.sh list` command to list all available community prompts
+- [ ] Add `dingen.sh for <name>` command to use existing prompts hosted on `https://dingen.sh/prompts`
+- [ ] Add `dingen.sh create "a thing to manage <tool>"` command to create new prompts with the help of LLMs (#inception)
+- [ ] Add `dingen.sh list` command to list all available community prompts
 
 ## The End
 

--- a/dingen.sh
+++ b/dingen.sh
@@ -39,7 +39,8 @@ copy_to_clipboard() {
 
 dingen() {
   local maxTokens=100
-  local usage="usage \`dingen.sh <system_prompt_file> [--max-tokens <number>] <user_prompt>\`"
+  local trust=false
+  local usage="usage \`dingen.sh <system_prompt_file> [--max-tokens <number>] [--trust] <user_prompt>\`"
 
   # Check for required commands early
   if ! command -v gh >/dev/null 2>&1; then
@@ -76,6 +77,12 @@ dingen() {
     fi
   fi
 
+  # Parse optional --trust argument
+  if [[ $# -ge 1 && "$1" == "--trust" ]]; then
+    trust=true
+    shift
+  fi
+
   # Validate that at least one user prompt argument exists
   if [[ $# -lt 1 ]]; then
     error "missing user prompt."
@@ -100,7 +107,6 @@ dingen() {
   echo "$command" | tee ~/.dingen.sh-last >/dev/null
 
   # Display generated command with syntax highlighting (fallback to echo if bat isn't installed)
-  echo "🕵️‍♀️ please review the generated command:"
   echo ""
   print_message 5 "\`\`\`bash"
   if command -v bat >/dev/null 2>&1; then
@@ -111,16 +117,21 @@ dingen() {
   print_message 5 "\`\`\`"
   echo ""
 
-  # copy to clipboard if available
+  # Copy to clipboard if available
   copy_to_clipboard "$command"
   
   # Confirm execution (quiet prompt)
-  read -p "🤷‍♂️ execute? (y/N): " confirm
-  if [[ "$confirm" =~ ^[Yy]$ ]]; then
-    echo -e "\n🚀 executing that dingens..."
+  if [[ "$trust" == true ]]; then
+    echo "🚀 executing that dingens..."
     eval "$command" || error "command execution failed."
   else
-    echo "🚮 command not executed."
+    read -p "🕵️‍♀️ please review the generated command above and decide if you want to execute it (y/N): " confirm
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+      echo -e "\n🚀 executing that dingens..."
+      eval "$command" || error "command execution failed."
+    else
+      echo "🚮 command not executed."
+    fi
   fi
 }
 


### PR DESCRIPTION
Add an optional `--trust` parameter to `dingen.sh` to run the generated command without user feedback.

* **dingen.sh**
  - Add a new optional parameter `--trust` to the `dingen` function to bypass user confirmation.
  - Update the usage string to include the `--trust` parameter.
  - Parse the `--trust` argument and set the `trust` variable accordingly.
  - Modify the confirmation step to check for the `--trust` parameter and skip the prompt if it is present.

* **README.md**
  - Update the usage instructions to include the `--trust` parameter.
  - Add a description of the `--trust` parameter in the "Arguments" section.
  - Add a cautionary note about using the `--trust` parameter with care.
  - Provide an example of using the `--trust` parameter in the "Example" section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mathiasschopmans/dingen.sh/pull/2?shareId=68375874-a406-4240-9a8a-dcec02b7ac8a).